### PR TITLE
all 3 layouts working... mobile default, tablet at 760, destop at 960…

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -4,8 +4,12 @@ body, html {
     padding:0;
     width: 100%;
     box-sizing: border-box;
+    display:flexbox;
   }
   main {
     margin:0 auto;
     padding:0px;
+  }
+  section {
+    display:flexbox;
   }

--- a/css/layout.css
+++ b/css/layout.css
@@ -1,60 +1,92 @@
 
 main{
     margin:0 auto;
-    width:490px;
+    width:460px;
 }
 header {
     float:left;
-    width:480px;
-    height:75px;
+    width:100%;
+    height:10%;
 }
 aside {
     float:left;
     margin:0 auto;
-    width: 480px;
-    height: 150px;
+    width: 100%;
+    height: 15%;
 }
 div {
     float:left;
 }
 section {
+    width:100%;
     margin:0 auto;
-    display:inline-block;
+    display:flexbox;
+    height:780px;
 }
 footer {
     float:left;
     margin:0 auto;
-    width:480px;
-    height:80px;
+    width:100%;
+    height:10%;
 }
 
-
-
-@media( min-width: 768px ) {
+@media ( min-width:760px){
+    main{
+        margin:0 auto;
+        width:80%;
+    }
+    header {
+        float:left;
+        width:100%;
+        height:10%;
+    }
+    aside {
+        float:left;
+        margin:0 auto;
+        width: 100%;
+        height: 15%;
+    }
+    div {
+        float:left;
+    }
+    section {
+        width:100%;
+        margin:0 auto;
+        display:flexbox;
+        height:780px;
+    }
+    footer {
+        float:left;
+        margin:0 auto;
+        width:100%;
+        height:10%;
+}
+@media( min-width: 960px ) {
     main{
         margin:0 auto;
         width:960px;
+        display:flexbox;
     }
     header {
-        width:960px;
-        height:100px;
+        width:100%;
+        height:10%;
     }
     aside {
         margin:0 auto;
-        width: 200px;
-        height: 600px;
-        float:left;
+        width: 20%;
+        height: 90%;
+        
     }
     div {
             }
     section {
         margin:0 auto;
-        display:inline-block;
+        display:flexbox;
     }
     footer {
         margin:0 auto;
-        width:760px;
-        height:150px;
+        width:80%;
+        height:10%;
         float:left;
         
     }

--- a/css/modules.css
+++ b/css/modules.css
@@ -1,26 +1,36 @@
+
+
 .tops {
-    width:480px;
-    height: 125px;
-    float:left;
+    width:100%;
+    height: 12.5%;
 }
 .bottoms {
-    width:240px;
-    height: 125px; 
-    float:left;
+    width:50%;
+    height: 25%; 
 }
 .clear {
     float:clear;
 }
-@media( min-width: 768px ) {
+
+@media ( min-width:760px){
 .tops {
-    width:380px;
-    height: 200px;
-    float:left;
+    width:100%;
+    height: 12.5%;
 }
 .bottoms {
-    width: 190px;
-    height: 250px;
-    float:left;
+    width: 50%;
+    height: 25%;
 }
-
+.clear {
+    float:clear;
+}
+}
+@media( min-width: 960px){
+    .tops {
+        width:80%;
+        height:15%;
+    }
+    .bottoms {
+        width:40%;
+    }
 }

--- a/css/theme.css
+++ b/css/theme.css
@@ -1,3 +1,4 @@
+
 header {
     background-color:lightblue;
 }
@@ -27,10 +28,39 @@ footer {
     color:wheat;
 }
 
+@media ( min-width:760px){
+    header {
+        background-color:rgb(63, 115, 133);
+    }
+    aside {
+        background-color: turquoise;
+    }
+    div:nth-of-type(1) {
+        background-color:rgb(121, 90, 50);
+    }
+    div:nth-of-type(2) {
+        background-color:rgb(136, 56, 70);
+    }
+    div:nth-of-type(3) {
+        background-color: rgb(43, 110, 43);
+    }
+    div:nth-of-type(4) {
+        background-color: rgb(126, 121, 121);
+    }
+    div:nth-of-type(5) {
+        background-color: rgb(97, 97, 10);
+    }
+    div:nth-of-type(6) {
+        background-color:rgb(156, 71, 156);
+    }
+    footer {
+        background-color: rgb(49, 32, 32);
+        color:wheat;
+    }
+}
 
 
-
-@media( min-width: 768px ) {
+@media( min-width: 960px ) {
     header {
         background-color: darkblue;
     }

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
    
-    <title>Lab 01- SMACSS Use</title>
+    <title>Lab 04- SMACSS Use || Flexbox or Grid</title>
     <link rel="stylesheet" href="css/reset.css">
     <link rel="stylesheet" href="css/style.css">
 </head>


### PR DESCRIPTION
…. different colors for all 3 layouts. mobile and tablet same relative design as mobile wireframe, and destop matches desktop, but using relative % measurements rather than px and flexbox instead of floats in inline-block